### PR TITLE
chore: approve esbuild build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   },
   "engines": {
     "node": ">=10.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
Adds `esbuild` to `pnpm.onlyBuiltDependencies` in `package.json` to resolve the `ERR_PNPM_IGNORED_BUILDS` warning for `esbuild@0.27.x`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014sjeGsayhfio1nZaLh8ysQ)_