### PR TITLE
chore: use pnpm v11 allowBuilds instead of onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,5 @@
   },
   "engines": {
     "node": ">=10.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
pnpm v11 removed `onlyBuiltDependencies` and replaced it with `allowBuilds` (a map of package name → boolean). This:\n- Adds a `pnpm-workspace.yaml` with the new `allowBuilds: {esbuild: true}` syntax\n- Removes the now-ignored `pnpm.onlyBuiltDependencies` from `package.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_014sjeGsayhfio1nZaLh8ysQ)_