### PR TITLE
build: SHA-pin reusable workflow references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,12 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 2
+    schedule:
+      interval: "cron"
+      cronjob: "0 17 * * 0"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: write # required for artifact upload in reusable workflow
-    uses: tylerkelly13/.github/.github/workflows/node-run-checks.yml@main
+    uses: tylerkelly13/.github/.github/workflows/node-run-checks.yml@57b7fbaf07c295fe93485f75bcf65449b070794b  # node-run-checks-civ2
     with:
       node-version: "24.x"
       pnpm-version: "latest"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
       actions: write # required for artifact upload in reusable workflow
-    uses: tylerkelly13/.github/.github/workflows/node-run-checks.yml@main
+    uses: tylerkelly13/.github/.github/workflows/node-run-checks.yml@57b7fbaf07c295fe93485f75bcf65449b070794b  # node-run-checks-civ2
     with:
       node-version: "24.x"
       pnpm-version: "latest"
@@ -22,6 +22,6 @@ jobs:
     needs: [Checks]
     permissions:
       contents: write # required to create GitHub releases
-    uses: tylerkelly13/.github/.github/workflows/node-gh-release.yml@main
+    uses: tylerkelly13/.github/.github/workflows/node-gh-release.yml@8d7d2e6616254a836736b88f3eb078caf96716db  # node-gh-release-civ1
     with:
       artifact-id: ${{ needs.Checks.outputs.artifact-id }}


### PR DESCRIPTION
Pins the central reusable-workflow references to immutable commit SHAs (civ-tagged), replacing `@main`.

- `node-run-checks` -> `@57b7fba` (`node-run-checks-civ2`, composite-action refs pinned)
- `node-gh-release` -> `@8d7d2e6` (`node-gh-release-civ1`)
- Adds the `github-actions` Dependabot ecosystem so these pins get bump PRs.

A single SHA pin on `node-run-checks` transitively locks its whole internal tree (internal calls use local paths). Verified upstream in `tylerkelly13/.github`.