### PR TITLE
chore: fix dependabot groups and set cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     cooldown:
-      default-days: 3
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
     groups:
-      applies-to: "version-updates"
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
     schedule:
       interval: "cron"
       cronjob: "0 17 * * 0"
@@ -16,9 +19,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      applies-to: "version-updates"
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
     cooldown:
-      default-days: 2
+      default-days: 7
     schedule:
       interval: "cron"
       cronjob: "0 17 * * 0"


### PR DESCRIPTION
- Fix malformed group structure (`applies-to` was used as a group name instead of a field)
- Bump `cooldown.default-days` to 7 on all ecosystems
- Add proper `dependencies` group (`applies-to: version-updates`) to both entries